### PR TITLE
Refactor/endpoint cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# edfi_api_client v0.2.1
+## Under the hood
+- Move several functions from `EdFiResource` to `EdFiEndpoint` to simplify inheritence between classes.
+- Genericize verbose endpoint logging to change depending on `type` of endpoint class.
+- Power `EdFiEndpoint.ping()` and `.total_count()` with internal helpers for improved logging.
+
+## Fixes
+- Make `EdFiEndpoint` class attributes into instance attributes
+- Fix bug in `EdFiComposite.get_pages()` where pages were not yielded
+
+
 # edfi_api_client v0.2.0
 ## New Features
 - `EdFiClient.get_swagger()` now returns an EdFiSwagger class that parses OpenAPI Swagger specification.

--- a/edfi_api_client/edfi_client.py
+++ b/edfi_api_client/edfi_client.py
@@ -7,7 +7,7 @@ from requests.exceptions import HTTPError
 from typing import Callable, Optional
 
 from edfi_api_client import util
-from edfi_api_client.edfi_endpoint import EdFiEndpoint, EdFiResource, EdFiDescriptor, EdFiComposite
+from edfi_api_client.edfi_endpoint import EdFiResource, EdFiDescriptor, EdFiComposite
 from edfi_api_client.edfi_swagger import EdFiSwagger
 
 
@@ -196,14 +196,6 @@ class EdFiClient:
             self.get_swagger(component)
 
     @property
-    def endpoints(self):
-        """
-
-        :return:
-        """
-        return self.resources + self.descriptors
-
-    @property
     def resources(self):
         """
 
@@ -356,23 +348,6 @@ class EdFiClient:
         return lower_json['newestchangeversion']
 
     @require_session
-    def endpoint(self,
-        name: str,
-
-        *,
-        namespace: str = 'ed-fi',
-        get_deletes: bool = False,
-
-        params: Optional[dict] = None,
-        **kwargs
-    ) -> EdFiEndpoint:
-        return EdFiEndpoint(
-            client=self,
-            name=name, namespace=namespace, get_deletes=get_deletes,
-            params=params, **kwargs
-        )
-
-    @require_session
     def resource(self,
         name: str,
 
@@ -408,7 +383,6 @@ class EdFiClient:
             name=name, namespace=namespace, get_deletes=False,
             params=params, **kwargs
         )
-
 
     @require_session
     def composite(self,

--- a/edfi_api_client/edfi_client.py
+++ b/edfi_api_client/edfi_client.py
@@ -195,6 +195,13 @@ class EdFiClient:
             )
             self.get_swagger(component)
 
+    @property
+    def endpoints(self):
+        """
+
+        :return:
+        """
+        return self.resources + self.descriptors
 
     @property
     def resources(self):

--- a/edfi_api_client/edfi_client.py
+++ b/edfi_api_client/edfi_client.py
@@ -1,4 +1,3 @@
-import logging
 import requests
 import time
 
@@ -11,6 +10,12 @@ from edfi_api_client import util
 from edfi_api_client.edfi_endpoint import EdFiResource, EdFiDescriptor, EdFiComposite
 from edfi_api_client.edfi_swagger import EdFiSwagger
 
+import logging
+logging.basicConfig(
+    level="INFO",
+    format='[%(asctime)s] %(levelname)-8s: %(message)s',
+    datefmt='%Y-%m-%d %H:%M:%S',
+)
 
 class EdFiClient:
     """

--- a/edfi_api_client/edfi_client.py
+++ b/edfi_api_client/edfi_client.py
@@ -7,7 +7,7 @@ from requests.exceptions import HTTPError
 from typing import Callable, Optional
 
 from edfi_api_client import util
-from edfi_api_client.edfi_endpoint import EdFiResource, EdFiDescriptor, EdFiComposite
+from edfi_api_client.edfi_endpoint import EdFiEndpoint, EdFiResource, EdFiDescriptor, EdFiComposite
 from edfi_api_client.edfi_swagger import EdFiSwagger
 
 
@@ -348,6 +348,22 @@ class EdFiClient:
         lower_json = {key.lower(): value for key, value in res.json().items()}
         return lower_json['newestchangeversion']
 
+    @require_session
+    def endpoint(self,
+        name: str,
+
+        *,
+        namespace: str = 'ed-fi',
+        get_deletes: bool = False,
+
+        params: Optional[dict] = None,
+        **kwargs
+    ) -> EdFiEndpoint:
+        return EdFiEndpoint(
+            client=self,
+            name=name, namespace=namespace, get_deletes=get_deletes,
+            params=params, **kwargs
+        )
 
     @require_session
     def resource(self,

--- a/edfi_api_client/edfi_endpoint.py
+++ b/edfi_api_client/edfi_endpoint.py
@@ -1,4 +1,3 @@
-import logging
 import requests
 import time
 
@@ -13,6 +12,12 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from edfi_api_client.edfi_client import EdFiClient
 
+import logging
+logging.basicConfig(
+    level="INFO",
+    format='[%(asctime)s] %(levelname)-8s: %(message)s',
+    datefmt='%Y-%m-%d %H:%M:%S',
+)
 
 class EdFiEndpoint:
     """
@@ -55,39 +60,21 @@ class EdFiEndpoint:
 
         # Build URL and dynamic params object
         self.get_deletes: bool = get_deletes
-        self.url = self.build_url()
+        self.url = self._build_endpoint_url()
         self.params = EdFiParams(params, **kwargs)
 
         # Swagger attributes are loaded lazily
-        self._description: Optional[str] = None
-        self._has_deletes: Optional[bool] = None
+        self.swagger = self.client.swaggers.get(self.swagger_type)
 
     def __repr__(self):
         """
         Endpoint (Deletes) (with {N} parameters) [{namespace}/{name}]
         """
-        _deletes_string = " Deletes" if self.get_deletes else ""
-        _params_string = f" with {len(self.params.keys())} parameters" if self.params else ""
-        _full_name = f"{util.snake_to_camel(self.namespace)}/{util.snake_to_camel(self.name)}"
+        deletes_string = " Deletes" if self.get_deletes else ""
+        params_string = f" with {len(self.params.keys())} parameters" if self.params else ""
+        full_name = f"{util.snake_to_camel(self.namespace)}/{util.snake_to_camel(self.name)}"
 
-        return f"<{self.type}{_deletes_string}{_params_string} [{_full_name}]>"
-
-
-    def build_url(self) -> str:
-        """
-        Build the name/descriptor URL to GET from the API.
-
-        :return:
-        """
-        # Deletes are an optional path addition.
-        deletes = 'deletes' if self.get_deletes else None
-
-        return util.url_join(
-            self.client.base_url,
-            self.client.version_url_string,
-            self.client.instance_locator,
-            self.namespace, self.name, deletes
-        )
+        return f"<{self.type}{deletes_string}{params_string} [{full_name}]>"
 
     def ping(self) -> requests.Response:
         """
@@ -113,10 +100,8 @@ class EdFiEndpoint:
 
         :return:
         """
-        self.client.verbose_log(
-            f"[Get {self.type}] Endpoint  : {self.url}\n"
-            f"[Get {self.type}] Parameters: {self.params}"
-        )
+        self.client.verbose_log(f"[Get {self.type}] Endpoint  : {self.url}")
+        self.client.verbose_log(f"[Get {self.type}] Parameters: {self.params}")
 
         params = self.params.copy()
 
@@ -195,7 +180,7 @@ class EdFiEndpoint:
                 f"[Paged Get {self.type}] Pagination Method: Change Version Stepping with Reverse-Offset Pagination"
             )
             paged_params.init_page_by_change_version_step(change_version_step_size)
-            total_count = self._get_total_count(paged_params)
+            total_count = self._get_total_count(self.url, paged_params)
             paged_params.init_reverse_page_by_offset(total_count, page_size)
 
         elif step_change_version:
@@ -240,7 +225,7 @@ class EdFiEndpoint:
                     )
                     try:
                         paged_params.page_by_change_version_step()  # This raises a StopIteration if max change version is exceeded.
-                        total_count = self._get_total_count(paged_params)
+                        total_count = self._get_total_count(self.url, paged_params)
                         paged_params.init_reverse_page_by_offset(total_count, page_size)
                     except StopIteration:
                         self.client.verbose_log(
@@ -276,59 +261,40 @@ class EdFiEndpoint:
 
         :return:
         """
-        params = self.params.copy()
-        return self._get_total_count(params)
-
-    def _get_total_count(self, params: EdFiParams):
-        """
-        `total_count()` is accessible by the user and during reverse offset-pagination.
-        This internal helper method prevents code needing to be defined twice.
-
-        :param params:
-        :return:
-        """
-        _params = params.copy()
-        _params['totalCount'] = True
-        _params['limit'] = 0
-
-        res = self._get_response(self.url, params=_params)
-        return int(res.headers.get('Total-Count'))
+        return self._get_total_count(self.url, self.params)
 
 
     ### Swagger-adjacent properties and helper methods
     @property
-    def description(self):
-        if self._description is None:
-            self._description = self._get_attributes_from_swagger()['description']
-        return self._description
+    def description(self) -> str:
+        if self.swagger is None:
+            self.swagger = self.client.get_swagger(self.swagger_type)
+        return self.swagger.descriptions.get(self.name)
 
     @property
-    def has_deletes(self):
-        if self._has_deletes is None:
-            self._has_deletes = self._get_attributes_from_swagger()['has_deletes']
-        return self._has_deletes
+    def has_deletes(self) -> bool:
+        if self.swagger is None:
+            self.swagger = self.client.get_swagger(self.swagger_type)
+        return (self.namespace, self.name) in self.swagger.deletes
 
 
-    def _get_attributes_from_swagger(self):
+    ### Internal helpers, GET response methods, and error-handling
+    def _build_endpoint_url(self) -> str:
         """
-        Retrieve endpoint-metadata from the Swagger document.
-
-        Populate the respective swagger object in `self.client` if not already populated.
+        Build the name/descriptor URL to GET from the API.
 
         :return:
         """
-        # Only GET the Swagger if not already populated in the client.
-        self.client._set_swagger(self.swagger_type)
-        swagger = self.client.swaggers[self.swagger_type]
+        # Deletes are an optional path addition.
+        deletes = 'deletes' if self.get_deletes else None
 
-        # Populate the attributes found in the swagger.
-        return {
-            'description': swagger.descriptions.get(self.name),
-            'has_deletes': (self.namespace, self.name) in swagger.deletes,
-        }
+        return util.url_join(
+            self.client.base_url,
+            self.client.version_url_string,
+            self.client.instance_locator,
+            self.namespace, self.name, deletes
+        )
 
-
-    ### Internal GET response methods and error-handling
     def reconnect_if_expired(func: Callable) -> Callable:
         """
         This decorator resets the connection with the API if expired.
@@ -340,12 +306,28 @@ class EdFiEndpoint:
         def wrapped(self, *args, **kwargs):
             # Refresh token if refresh_time has passed
             if self.client.session.refresh_time < int(time.time()):
-                self.client.verbose_log(
-                    "Session authentication is expired. Attempting reconnection..."
-                )
+                self.client.verbose_log("Session authentication is expired. Attempting reconnection...")
                 self.client.connect()
+
             return func(self, *args, **kwargs)
         return wrapped
+
+    @reconnect_if_expired
+    def _get_total_count(self, url: str, params: EdFiParams):
+        """
+        `total_count()` is accessible by the user and during reverse offset-pagination.
+        This internal helper method prevents code needing to be defined twice.
+
+        :param url:
+        :param params:
+        :return:
+        """
+        _params = params.copy()
+        _params['totalCount'] = True
+        _params['limit'] = 0
+
+        res = self._get_response(url, params=_params)
+        return int(res.headers.get('Total-Count'))
 
     @reconnect_if_expired
     def _get_response(self,
@@ -490,7 +472,7 @@ class EdFiComposite(EdFiEndpoint):
         params: Optional[dict] = None,
         **kwargs
     ):
-        # Assign composite-specific arguments that are used in `self.build_url()`.
+        # Assign composite-specific arguments that are used in `self._build_endpoint_url()`.
         self.composite: str = composite
         self.filter_type: Optional[str] = filter_type
         self.filter_id: Optional[str] = filter_id
@@ -502,39 +484,24 @@ class EdFiComposite(EdFiEndpoint):
         Enrollment Composite                     [{namespace}/{name}]
                              with {N} parameters                      (filtered on {filter_type})
         """
-        _composite = self.composite.title()
-        _params_string = f" with {len(self.params.keys())} parameters" if self.params else ""
-        _full_name = f"{util.snake_to_camel(self.namespace)}/{util.snake_to_camel(self.name)}"
-        _filter_string = f" (filtered on {self.filter_type})" if self.filter_type else ""
+        composite = self.composite.title()
+        params_string = f" with {len(self.params.keys())} parameters" if self.params else ""
+        full_name = f"{util.snake_to_camel(self.namespace)}/{util.snake_to_camel(self.name)}"
+        filter_string = f" (filtered on {self.filter_type})" if self.filter_type else ""
 
-        return f"<{_composite} Composite{_params_string} [{_full_name}]{_filter_string}>"
+        return f"<{composite} Composite{params_string} [{full_name}]{filter_string}>"
 
-    def build_url(self) -> str:
+    def total_count(self):
         """
-        Build the composite URL to GET from the API.
+        Ed-Fi 3 resources/descriptors can be fed an optional 'totalCount' parameter in GETs.
+        This returns a 'Total-Count' in the response headers that gives the total number of rows for that resource with the specified params.
+        Non-pagination params (i.e., offset and limit) have no impact on the returned total.
 
         :return:
         """
-        # If a filter is applied, the URL changes to match the filter type.
-        if self.filter_type is None and self.filter_id is None:
-            return util.url_join(
-                self.client.base_url, 'composites/v1',
-                self.client.instance_locator,
-                self.namespace, self.composite, self.name.title()
-            )
-
-        elif self.filter_type is not None and self.filter_id is not None:
-            return util.url_join(
-                self.client.base_url, 'composites/v1',
-                self.client.instance_locator,
-                self.namespace, self.composite,
-                self.filter_type, self.filter_id, self.name
-            )
-
-        else:
-            raise ValueError(
-                "`filter_type` and `filter_id` must both be specified if a filter is being applied!"
-            )
+        raise NotImplementedError(
+            "Total counts have not yet been implemented in Ed-Fi composites!"
+        )
 
     def get_pages(self,
         *,
@@ -570,14 +537,29 @@ class EdFiComposite(EdFiEndpoint):
         )
         yield from composite_pages
 
-    def total_count(self):
+    def _build_endpoint_url(self) -> str:
         """
-        Ed-Fi 3 resources/descriptors can be fed an optional 'totalCount' parameter in GETs.
-        This returns a 'Total-Count' in the response headers that gives the total number of rows for that resource with the specified params.
-        Non-pagination params (i.e., offset and limit) have no impact on the returned total.
+        Build the composite URL to GET from the API.
 
         :return:
         """
-        raise NotImplementedError(
-            "Total counts have not yet been implemented in Ed-Fi composites!"
-        )
+        # If a filter is applied, the URL changes to match the filter type.
+        if self.filter_type is None and self.filter_id is None:
+            return util.url_join(
+                self.client.base_url, 'composites/v1',
+                self.client.instance_locator,
+                self.namespace, self.composite, self.name.title()
+            )
+
+        elif self.filter_type is not None and self.filter_id is not None:
+            return util.url_join(
+                self.client.base_url, 'composites/v1',
+                self.client.instance_locator,
+                self.namespace, self.composite,
+                self.filter_type, self.filter_id, self.name
+            )
+
+        else:
+            raise ValueError(
+                "`filter_type` and `filter_id` must both be specified if a filter is being applied!"
+            )

--- a/edfi_api_client/edfi_endpoint.py
+++ b/edfi_api_client/edfi_endpoint.py
@@ -557,12 +557,13 @@ class EdFiComposite(EdFiEndpoint):
                 "Remove `step_change_version`, `change_version_step_size`, and/or `reverse_paging` from arguments."
             )
 
-        super().get_pages(
+        composite_pages = super().get_pages(
             page_size=page_size,
             retry_on_failure=retry_on_failure,
             max_retries=max_retries,
             max_wait=max_wait
         )
+        yield from composite_pages
 
     def total_count(self):
         """

--- a/edfi_api_client/edfi_endpoint.py
+++ b/edfi_api_client/edfi_endpoint.py
@@ -560,10 +560,9 @@ class EdFiComposite(EdFiEndpoint):
         :param max_wait:
         :return:
         """
-        if 'step_change_version' in kwargs or 'change_version_step_size' in kwargs or 'reverse_paging' in kwargs:
+        if kwargs.get('step_change_version'):
             raise KeyError(
-                "Change versions are not implemented in composites!\n"
-                "Remove `step_change_version`, `change_version_step_size`, and/or `reverse_paging` from arguments."
+                "Change versions are not implemented in composites! Remove `step_change_version` from arguments."
             )
 
         composite_pages = super().get_pages(

--- a/edfi_api_client/edfi_endpoint.py
+++ b/edfi_api_client/edfi_endpoint.py
@@ -12,12 +12,6 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from edfi_api_client.edfi_client import EdFiClient
 
-import logging
-logging.basicConfig(
-    level="INFO",
-    format='[%(asctime)s] %(levelname)-8s: %(message)s',
-    datefmt='%Y-%m-%d %H:%M:%S',
-)
 
 class EdFiEndpoint:
     """

--- a/edfi_api_client/edfi_endpoint.py
+++ b/edfi_api_client/edfi_endpoint.py
@@ -19,14 +19,8 @@ class EdFiEndpoint:
     This is an abstract class for interacting with Ed-Fi resources and descriptors.
     Composites override EdFiEndpoint with custom composite-logic.
     """
-    type: str = 'Endpoint'
+    type: str = None
     swagger_type: str = None
-
-    def __new__(cls, *args, name: str, **kwargs):
-        if "descriptor" in name.lower():
-            return object.__new__(EdFiDescriptor)
-        else:
-            return object.__new__(EdFiResource)
 
     def __init__(self,
          client: 'EdFiClient',

--- a/edfi_api_client/edfi_endpoint.py
+++ b/edfi_api_client/edfi_endpoint.py
@@ -258,7 +258,7 @@ class EdFiEndpoint:
         for paged_result in paged_result_iter:
             yield from paged_result
 
-    def to_json(self,
+    def get_to_json(self,
         path: str,
 
         *,

--- a/edfi_api_client/edfi_endpoint.py
+++ b/edfi_api_client/edfi_endpoint.py
@@ -235,7 +235,7 @@ class EdFiEndpoint:
             ### Paginate, depending on the method specified in arguments
             # Reverse offset pagination is only applicable during change-version stepping.
             if step_change_version and reverse_paging:
-                self.client.verbose_log("[Paged Get {self.type}] @ Reverse-paginating offset...")
+                self.client.verbose_log(f"[Paged Get {self.type}] @ Reverse-paginating offset...")
                 try:
                     paged_params.reverse_page_by_offset()
                 except StopIteration:

--- a/edfi_api_client/edfi_endpoint.py
+++ b/edfi_api_client/edfi_endpoint.py
@@ -83,9 +83,6 @@ class EdFiEndpoint:
         """
         Build the name/descriptor URL to GET from the API.
 
-        :param name:
-        :param namespace:
-        :param get_deletes:
         :return:
         """
         # Deletes are an optional path addition.

--- a/edfi_api_client/edfi_endpoint.py
+++ b/edfi_api_client/edfi_endpoint.py
@@ -271,7 +271,7 @@ class EdFiEndpoint:
         step_change_version: bool = False,
         change_version_step_size: int = 50000,
         reverse_paging: bool = True,
-    ):
+    ) -> str:
         """
         This method completes a series of GET requests, paginating params as necessary based on endpoint.
         Rows are written to a file as JSON lines.
@@ -297,6 +297,8 @@ class EdFiEndpoint:
         with open(path, 'wb') as fp:
             for page in paged_results:
                 fp.write(util.page_to_bytes(page))
+
+        return path
 
 
     ### Swagger-adjacent properties and helper methods

--- a/edfi_api_client/edfi_endpoint.py
+++ b/edfi_api_client/edfi_endpoint.py
@@ -115,40 +115,6 @@ class EdFiEndpoint:
 
         return self._get_response(self.url, params=params).json()
 
-    def get_rows(self,
-        *,
-        page_size: int = 100,
-
-        retry_on_failure: bool = False,
-        max_retries: int = 5,
-        max_wait: int = 500,
-
-        step_change_version: bool = False,
-        change_version_step_size: int = 50000,
-        reverse_paging: bool = True
-    ) -> Iterator[dict]:
-        """
-        This method returns all rows from an endpoint, applying pagination logic as necessary.
-        Rows are returned as a generator.
-
-        :param page_size:
-        :param retry_on_failure:
-        :param max_retries:
-        :param max_wait:
-        :param step_change_version:
-        :param change_version_step_size:
-        :param reverse_paging:
-        :return:
-        """
-        paged_result_iter = self.get_pages(
-            page_size=page_size,
-            retry_on_failure=retry_on_failure, max_retries=max_retries, max_wait=max_wait,
-            step_change_version=step_change_version, change_version_step_size=change_version_step_size, reverse_paging=reverse_paging
-        )
-
-        for paged_result in paged_result_iter:
-            yield from paged_result
-
     def get_pages(self,
         *,
         page_size: int = 100,
@@ -258,6 +224,40 @@ class EdFiEndpoint:
                     self.client.verbose_log(f"@ Paginating offset...")
                     paged_params.page_by_offset()
 
+    def get_rows(self,
+        *,
+        page_size: int = 100,
+
+        retry_on_failure: bool = False,
+        max_retries: int = 5,
+        max_wait: int = 500,
+
+        step_change_version: bool = False,
+        change_version_step_size: int = 50000,
+        reverse_paging: bool = True
+    ) -> Iterator[dict]:
+        """
+        This method returns all rows from an endpoint, applying pagination logic as necessary.
+        Rows are returned as a generator.
+
+        :param page_size:
+        :param retry_on_failure:
+        :param max_retries:
+        :param max_wait:
+        :param step_change_version:
+        :param change_version_step_size:
+        :param reverse_paging:
+        :return:
+        """
+        paged_result_iter = self.get_pages(
+            page_size=page_size,
+            retry_on_failure=retry_on_failure, max_retries=max_retries, max_wait=max_wait,
+            step_change_version=step_change_version, change_version_step_size=change_version_step_size, reverse_paging=reverse_paging
+        )
+
+        for paged_result in paged_result_iter:
+            yield from paged_result
+
     def to_json(self,
         path: str,
 
@@ -297,6 +297,7 @@ class EdFiEndpoint:
         with open(path, 'wb') as fp:
             for page in paged_results:
                 fp.write(util.page_to_bytes(page))
+
 
     ### Swagger-adjacent properties and helper methods
     @property

--- a/edfi_api_client/edfi_endpoint.py
+++ b/edfi_api_client/edfi_endpoint.py
@@ -133,7 +133,9 @@ class EdFiEndpoint:
         max_retries: int = 5,
         max_wait: int = 500,
 
-        **kwargs
+        step_change_version: bool = False,
+        change_version_step_size: int = 50000,
+        reverse_paging: bool = True
     ) -> Iterator[dict]:
         """
         This method returns all rows from an endpoint, applying pagination logic as necessary.
@@ -143,12 +145,15 @@ class EdFiEndpoint:
         :param retry_on_failure:
         :param max_retries:
         :param max_wait:
+        :param step_change_version:
+        :param change_version_step_size:
+        :param reverse_paging:
         :return:
         """
         paged_result_iter = self.get_pages(
             page_size=page_size,
             retry_on_failure=retry_on_failure, max_retries=max_retries, max_wait=max_wait,
-            **kwargs
+            step_change_version=step_change_version, change_version_step_size=change_version_step_size, reverse_paging=reverse_paging
         )
 
         for paged_result in paged_result_iter:

--- a/edfi_api_client/edfi_swagger.py
+++ b/edfi_api_client/edfi_swagger.py
@@ -39,13 +39,11 @@ class EdFiSwagger:
         # Extract surrogate keys from `definitions`
         self.reference_skeys: dict = self.get_reference_skeys(exclude=['link',])
 
-
     def __repr__(self):
         """
         Ed-Fi {self.type} OpenAPI Swagger Specification
         """
         return f"<Ed-Fi {self.type.title()} OpenAPI Swagger Specification>"
-
 
     def _get_namespaced_endpoints_and_deletes(self):
         """
@@ -73,7 +71,6 @@ class EdFiSwagger:
 
         return resource_deletes
 
-
     def get_descriptions(self):
         """
         Descriptions for all EdFi endpoints are found under `tags` as [name, description] JSON objects.
@@ -86,7 +83,6 @@ class EdFiSwagger:
             tag['name']: tag['description']
             for tag in self.json['tags']
         }
-
 
     def get_reference_skeys(self, exclude: List[str]):
         """

--- a/edfi_api_client/util.py
+++ b/edfi_api_client/util.py
@@ -1,6 +1,7 @@
-import datetime
+import json
 import re
 
+from typing import List
 
 def camel_to_snake(name: str) -> str:
     """
@@ -14,7 +15,6 @@ def camel_to_snake(name: str) -> str:
     name = re.sub(r'[_ ]+', '_', name)
     return name.lower()
 
-
 def snake_to_camel(name: str) -> str:
     """
     Convert snake_case names to camelCase names.
@@ -25,6 +25,8 @@ def snake_to_camel(name: str) -> str:
     words = re.split(r"[_-]+", name)
     return words[0] + ''.join(word.title() for word in words[1:])
 
+def page_to_bytes(page: List[dict]) -> bytes:
+    return b''.join(map(lambda row: json.dumps(row).encode('utf-8') + b'\n', page))
 
 def url_join(*args) -> str:
     return '/'.join(

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ README = (HERE / "README.md").read_text()
 
 setuptools.setup(
       name='edfi_api_client',
-      version='0.2.0',
+      version='0.2.1',
       description='Ed-Fi API client and tools',
       license_files=['LICENSE'],
       url='https://github.com/edanalytics/edfi_api_client',

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ README = (HERE / "README.md").read_text()
 
 setuptools.setup(
       name='edfi_api_client',
-      version='0.2.1',
+      version='0.3.0',
       description='Ed-Fi API client and tools',
       license_files=['LICENSE'],
       url='https://github.com/edanalytics/edfi_api_client',


### PR DESCRIPTION
# refactor/endpoint_cleanup

## Description & motivation
This is a quality-of-life refactor of `EdFiEndpoint` to streamline inheritance between `EdFiEndpoint`, `EdFiResource`, and `EdFiDescriptor`. All generic logic is defined in `EdFiEndpoint`, with only class attributes being defined for resources and descriptors. This reduces the unique locations of overridden functions throughout the project.

Other features:
* Fully integrate the `logging` library into the package (for future updates)
* General whitespace cleanup and method reordering for ease of use.
* Simplify Swagger-adjacent method to limit the number of private instance attributes defined throughout the package.

## PR Merge Priority:
- [x] Low
- [ ] Medium
- [ ] High

## Tests and QC done:
I have rerun ad-hoc tests of all functions using one of the Ed-Fi ODSes in production.