### PR TITLE
Make api_mode optional

### DIFF
--- a/edfi_api_client/edfi_client.py
+++ b/edfi_api_client/edfi_client.py
@@ -93,7 +93,7 @@ class EdFiClient:
         (Un)Authenticated Ed-Fi(2/3) Client [{api_mode}]
         """
         _session_string = "Authenticated" if self.session else "Unauthenticated"
-        _api_mode = util.snake_to_camel(self.api_mode)
+        _api_mode = util.snake_to_camel(self.api_mode) if self.api_mode else "None"
         if self.api_year:
             _api_mode += f" {self.api_year}"
 
@@ -129,14 +129,14 @@ class EdFiClient:
         return requests.get(self.base_url, verify=self.verify_ssl).json()
 
 
-    def get_api_mode(self) -> str:
+    def get_api_mode(self) -> Optional[str]:
         """
         Retrieve api_mode from the metadata exposed at the API root.
 
         :return:
         """
         api_mode = self.get_info().get('apiMode')
-        return util.camel_to_snake(api_mode)
+        return util.camel_to_snake(api_mode) if api_mode else None
 
 
     def get_ods_version(self) -> Optional[str]:

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ README = (HERE / "README.md").read_text()
 
 setuptools.setup(
       name='edfi_api_client',
-      version='0.2.0',
+      version='0.2.1',
       description='Ed-Fi API client and tools',
       license_files=['LICENSE'],
       url='https://github.com/edanalytics/edfi_api_client',


### PR DESCRIPTION
Instantiating `EdFiClient` with an Ed-Fi v7 environment will fail with this exception, "expected string or bytes-like object".  Ed-Fi v7 no longer uses api modes, and `apiMode` is no longer returned in the base url json.  The error is thrown when trying to parse a None object with `util.camel_to_snake()`.  This PR makes updates to prevent calling that function when api_mode is None.  This code has been tested with a script that only makes use of the get_info() method unauthenticated.  It has not been tested for making authenticated calls to Ed-Fi v7.  