### PR TITLE
Rc/0.3.0  deprecate client getters

### DIFF
--- a/edfi_api_client/client.py
+++ b/edfi_api_client/client.py
@@ -61,7 +61,7 @@ class EdFiClient:
         self._info: Optional[dict] = None
 
         self.api_version: int = int(api_version)
-        self._api_mode: str = api_mode  # Make non-public to allow similar syntax for all info getters.
+        self.api_mode: str = api_mode or self.get_api_mode()  # Populates self._info to infer mode from ODS.
         self.api_year: Optional[int] = api_year
         self.instance_code: Optional[str] = instance_code
 
@@ -131,26 +131,15 @@ class EdFiClient:
         """
         return requests.get(self.base_url, verify=self.verify_ssl).json()
 
-    # API Mode
-    @property
-    def api_mode(self) -> Optional[str]:
+    # API Mode (attribute is set during init)
+    def get_api_mode(self) -> Optional[str]:
         """
         Retrieve api_mode from the metadata exposed at the API root.
+        After API mode is deprecated in Ed-Fi 7, we can consider deprecating this method.
         :return:
         """
-        # Default to user-provided API mode if specified.
-        if self._api_mode:
-            return self._api_mode
-
         api_mode = self.info.get('apiMode')
         return util.camel_to_snake(api_mode) if api_mode else None
-
-    @deprecation.deprecated(
-        deprecated_in="0.3.0", removed_in="0.4.0", current_version=importlib.metadata.version('edfi_api_client'),
-        details="Get attributes directly using `EdFiClient.api_mode`."
-    )
-    def get_api_mode(self) -> Optional[str]:
-        return self.api_mode
 
     # ODS Version
     @property

--- a/edfi_api_client/swagger.py
+++ b/edfi_api_client/swagger.py
@@ -33,22 +33,18 @@ class EdFiSwagger:
         """
         return f"<Ed-Fi {self.component.title()} OpenAPI Swagger Specification>"
 
-
-    @classmethod
-    def get_swagger(cls, base_url: str, component: str = 'resources') -> dict:
+    def get_json(self) -> dict:
         """
         OpenAPI Specification describes the entire Ed-Fi API surface in a
         JSON payload.
         Can be used to surface available endpoints.
 
-        :param base_url:
-        :param component: Which component's swagger spec should be retrieved?
         :return: Swagger specification definition, as a dictionary.
         """
-        logging.info(f"[Get {component.title()} Swagger] Retrieving Swagger into memory...")
+        logging.info(f"[Get {self.component.title()} Swagger] Retrieving Swagger into memory...")
 
         swagger_url = util.url_join(
-            base_url, 'metadata', 'data/v3', component, 'swagger.json'
+            self.base_url, 'metadata', 'data/v3', self.component, 'swagger.json'
         )
 
         return requests.get(swagger_url).json()
@@ -57,7 +53,7 @@ class EdFiSwagger:
     @property
     def payload(self) -> dict:
         if self._json is None:
-            self._json = self.get_swagger(self.base_url, self.component)
+            self._json = self.get_json()
         return self._json
 
     @property

--- a/edfi_api_client/tests/test_client.py
+++ b/edfi_api_client/tests/test_client.py
@@ -28,8 +28,8 @@ def test_unauthenticated_client(secret: str, verbose: bool = False):
 
     ### Swagger
     print(edfi.get_swagger(component='resources'))
-    print(edfi.get_swagger(component='descriptors'))
-    print(edfi.get_swagger(component='composites'))
+    print(edfi.descriptors_swagger)
+    print(edfi.composites_swagger.version_url_string)
 
     ### Authenticated methods
     with pytest.raises(ValueError):

--- a/edfi_api_client/tests/test_client.py
+++ b/edfi_api_client/tests/test_client.py
@@ -20,6 +20,12 @@ def test_unauthenticated_client(secret: str, verbose: bool = False):
     payload_keys = ('apiMode', 'version', 'dataModels', 'urls',)
     assert all(key in info_payload for key in payload_keys)
 
+    ### Deprecated getters
+    print(edfi.get_api_mode())
+    print(edfi.get_ods_version())
+    print(edfi.get_data_model_version())
+    print(edfi.get_instance_locator())
+
     ### Swagger
     print(edfi.get_swagger(component='resources'))
     print(edfi.get_swagger(component='descriptors'))

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,14 @@
 import pathlib
 import setuptools
 
+VERSION = "0.3.0"
 HERE = pathlib.Path(__file__).parent
 README = (HERE / "README.md").read_text()
 
+
 setuptools.setup(
       name='edfi_api_client',
-      version='0.3.0',
+      version=VERSION,
       description='Ed-Fi API client and tools',
       license_files=['LICENSE'],
       url='https://github.com/edanalytics/edfi_api_client',


### PR DESCRIPTION
Mark EdFiClient.get_attribute() methods as deprecated; make Swagger lazy to simplify argument passing to endpoint inits.