### PR TITLE
Add option for 'Use-Snapshot' header

### DIFF
--- a/edfi_api_client/edfi_client.py
+++ b/edfi_api_client/edfi_client.py
@@ -23,6 +23,7 @@ class EdFiClient:
     :param api_mode: ['shared_instance', 'sandbox', 'district_specific', 'year_specific', 'instance_year_specific']
     :param api_year: Required only for 'year_specific' or 'instance_year_specific' modes
     :param instance_code: Only required for 'instance_specific' or 'instance_year_specific modes'
+    :param use_snapshot: Add 'Use-Snapshot' header to requests
     """
     def __new__(cls, *args, **kwargs):
         """
@@ -50,6 +51,7 @@ class EdFiClient:
         api_mode     : Optional[str] = None,
         api_year     : Optional[int] = None,
         instance_code: Optional[str] = None,
+        use_snapshot : bool = False,
 
         verify_ssl   : bool = True,
         verbose      : bool = False,
@@ -66,6 +68,7 @@ class EdFiClient:
         self.api_mode = api_mode or self.get_api_mode()
         self.api_year = api_year
         self.instance_code = instance_code
+        self.use_snapshot = use_snapshot
 
         # Build endpoint URL pieces
         self.version_url_string = self._get_version_url_string()
@@ -306,6 +309,8 @@ class EdFiClient:
         # Create a session and add headers to it.
         self.session = requests.Session()
         self.session.headers.update(req_header)
+        if self.use_snapshot:
+            self.session.headers.update({'Use-Snapshot': 'True'})
 
         # Add new attributes to track when connection was established and when to refresh the access token.
         self.session.timestamp_unix = int(time.time())


### PR DESCRIPTION
This PR adds a boolean option to include the 'Use-Snapshot' header.  This allows for reading data from a snapshot of the ODS instead of the live ODS.  This was tested by requesting information from a dev environment with a snapshot and toggling the `use_snapshot` option on and off.  Verified that requests go to the live ODS without the option, and to the snapshot ODS when `use_snapshot=True`.

It should be noted that this functionality only works for Ed-Fi 7.x environments.  Older environments used a different method for accessing snapshots, and would require different parameters.  The `use_snapshot` option added here would not impact the ability to support older Ed-Fi snapshots in the future.