### PR TITLE
Feature/migrate session from rc

### DIFF
--- a/edfi_api_client/edfi_endpoint.py
+++ b/edfi_api_client/edfi_endpoint.py
@@ -45,6 +45,9 @@ class EdFiEndpoint:
         # self.swagger: 'EdFiSwagger' = swagger
         # self.validator: 'Draft4Validator' = None
 
+        self._description: Optional[str]  = None
+        self._has_deletes: Optional[bool] = None
+
 
     def __repr__(self):
         """
@@ -109,7 +112,7 @@ class EdFiEndpoint:
         logging.info(f"[Ping {self.component}] Endpoint: {self.url}")
 
         # Override init params if passed
-        params = (params or self.params).copy()
+        params = EdFiParams(params or self.params).copy()
         params['limit'] = 1  # To ping a composite, a limit of at least one is required.
 
         # We do not want to surface student-level data during ODS-checks.
@@ -129,7 +132,7 @@ class EdFiEndpoint:
         logging.info(f"[Get {self.component}] Endpoint: {self.url}")
 
         # Override init params if passed
-        params = (params or self.params).copy()
+        params = EdFiParams(params or self.params).copy()
         if limit:  # Override limit if passed
             params['limit'] = limit
 
@@ -261,7 +264,7 @@ class EdFiEndpoint:
         logging.info(f"[Get Total Count {self.component}] Endpoint: {self.url}")
 
         # Override init params if passed
-        params = (params or self.params).copy()
+        params = EdFiParams(params or self.params).copy()
         params['totalCount'] = True
         params['limit'] = 0
 
@@ -409,7 +412,7 @@ class EdFiComposite(EdFiEndpoint):
         logging.info(f"[Paged Get {self.component}] Pagination Method: Offset Pagination")
 
         # Reset pagination parameters
-        paged_params = (params or self.params).copy()
+        paged_params = EdFiParams(params or self.params).copy()
         paged_params.init_page_by_offset(page_size)
 
         # Begin pagination-loop

--- a/edfi_api_client/edfi_endpoint.py
+++ b/edfi_api_client/edfi_endpoint.py
@@ -1,11 +1,8 @@
 import abc
 import logging
 import requests
-import time
 
-from functools import wraps
-from requests.exceptions import HTTPError, RequestsWarning
-from typing import Callable, Iterator, List, Optional, Tuple, Union
+from typing import Iterator, List, Optional, Tuple, Union
 
 from edfi_api_client.edfi_params import EdFiParams
 from edfi_api_client import util
@@ -17,97 +14,136 @@ if TYPE_CHECKING:
 
 class EdFiEndpoint:
     """
-
+    This is an abstract class for interacting with Ed-Fi resources and descriptors.
+    Composites override with custom composite-logic.
     """
-    client: 'EdFiClient'
-    name: str
-    namespace: Optional[str]
-
-    url: str
-    params: EdFiParams
-
-    # Swagger name and attributes loaded lazily from Swagger
-    swagger_type: str
-    _description: Optional[str]  = None
-    _has_deletes: Optional[bool] = None
-
+    component: str = None
 
     def __init__(self,
         client: 'EdFiClient',
         name: Union[str, Tuple[str, str]],
-        namespace: str = 'ed-fi'
+        namespace: str = 'ed-fi',
+        get_deletes: bool = False,
+        get_key_changes: bool = False,
+        params: Optional[dict] = None,
+        **kwargs
     ):
         self.client: 'EdFiClient' = client
 
-        # Name and namespace can be passed manually
-        if isinstance(name, str):
-            self.name: str = util.snake_to_camel(name)
-            self.namespace: str = namespace
+        # Names can be passed manually or as a `(namespace, name)` tuple as output from Swagger.
+        self.namespace, self.name = self._parse_names(self.client, namespace, name)
+        self.params = EdFiParams(params, **kwargs)
 
-        # Or as a `(namespace, name)` tuple as output from Swagger
-        else:
-            try:
-                self.namespace, self.name = name
-            except ValueError:
-                logging.error(
-                    "Arguments `name` and `namespace` must be passed explicitly, or as a `(namespace, name)` tuple."
-                )
+        # GET-specific deletes and keyChanges endpoints
+        self.get_deletes: bool = get_deletes
+        self.get_key_changes: bool = get_key_changes
+        if self.get_deletes and self.get_key_changes:
+            raise ValueError("Endpoint arguments `get_deletes` and `get_key_changes` are mutually-exclusive.")
 
-        # Namespaces are not implemented in EdFi 2.x.
-        if self.client.is_edfi2():
-            self.namespace = None
+        # Optional helper classes with lazy attributes
+        self.client: 'EdFiClient' = client
+        # self.swagger: 'EdFiSwagger' = swagger
+        # self.validator: 'Draft4Validator' = None
 
 
-    @abc.abstractmethod
-    def build_url(self):
+    def __repr__(self):
         """
-        This method builds the endpoint URL with namespacing and optional pathing.
+        Endpoint (Deletes) (with {N} parameters) [{namespace}/{name}]
+        """
+        if self.get_deletes:
+            extras_string = " Deletes"
+        elif self.get_key_changes:
+            extras_string = " KeyChanges"
+        else:
+            extras_string = ""
+
+        params_string = f" with {len(self.params.keys())} parameters" if self.params else ""
+        return f"<{self.component}{extras_string}{params_string} [{self.raw}]>"
+    
+
+    ### Naming and Pathing Methods
+    @staticmethod
+    def _parse_names(client: 'EdFiClient', namespace: str, name: str) -> Tuple[str, str]:
+        """
+        Name and namespace can be passed manually or as a `(namespace, name)` tuple as output from Swagger.
+        """
+        if isinstance(name, str):
+            return namespace, util.snake_to_camel(name)
+        elif len(name) == 2:
+            return name
+        else:
+            logging.error("Arguments `namespace` and `name` must be passed explicitly, or as a `(namespace, name)` tuple.")
+
+    @property
+    def raw(self) -> str:
+        return f"{util.snake_to_camel(self.namespace)}/{util.snake_to_camel(self.name)}"
+
+    @property
+    def url(self) -> str:
+        """
+        Build the name/descriptor URL to GET from the API.
+        Include namespacing and optional pathing.
+
         :return:
         """
-        raise NotImplementedError
+        # Deletes/keyChanges are an optional path addition.
+        if self.get_deletes:
+            path_extra = 'deletes'
+        elif self.get_key_changes:
+            path_extra = 'keyChanges'
+        else:
+            path_extra = None
+
+        return util.url_join(
+            self.client.base_url, 'data/v3', self.client.get_instance_locator(),
+            self.namespace, self.name, path_extra
+        )
 
 
-    def ping(self) -> requests.Response:
+    def ping(self, *, params: Optional[dict] = None, **kwargs) -> requests.Response:
         """
         This method pings the endpoint and verifies it is accessible.
 
         :return:
         """
-        params = self.params.copy()
-        params['limit'] = 1
+        logging.info(f"[Ping {self.component}] Endpoint: {self.url}")
 
-        res = self.client.session.get(self.url, params=params)
+        # Override init params if passed
+        params = (params or self.params).copy()
+        params['limit'] = 1  # To ping a composite, a limit of at least one is required.
 
-        # To ping a composite, a limit of at least one is required.
         # We do not want to surface student-level data during ODS-checks.
+        res = self.client.session.get_response(self.url, params=params, **kwargs)
         if res.ok:
             res._content = b'{"message": "Ping was successful! ODS data has been intentionally scrubbed from this response."}'
 
         return res
 
 
-    def get(self, limit: Optional[int] = None) -> List[dict]:
+    def get(self, limit: Optional[int] = None, *, params: Optional[dict] = None, **kwargs) -> List[dict]:
         """
         This method returns the rows from a single GET request using the exact params passed by the user.
 
         :return:
         """
-        params = self.params.copy()
+        logging.info(f"[Get {self.component}] Endpoint: {self.url}")
 
-        if limit is not None:
+        # Override init params if passed
+        params = (params or self.params).copy()
+        if limit:  # Override limit if passed
             params['limit'] = limit
 
-        return self._get_response(self.url, params=params).json()
+        logging.info(f"[Get {self.component}] Parameters: {params}")
+        return self.client.session.get_response(self.url, params=params, **kwargs).json()
 
 
     def get_rows(self,
         *,
+        params: Optional[dict] = None,  # Optional alternative params
         page_size: int = 100,
-
-        retry_on_failure: bool = False,
-        max_retries: int = 5,
-        max_wait: int = 500,
-
+        reverse_paging: bool = True,
+        step_change_version: bool = False,
+        change_version_step_size: int = 50000,
         **kwargs
     ) -> Iterator[dict]:
         """
@@ -121,43 +157,100 @@ class EdFiEndpoint:
         :return:
         """
         paged_result_iter = self.get_pages(
-            page_size=page_size,
-            retry_on_failure=retry_on_failure, max_retries=max_retries, max_wait=max_wait,
+            params=params,
+            page_size=page_size, reverse_paging=reverse_paging,
+            step_change_version=step_change_version, change_version_step_size=change_version_step_size,
             **kwargs
         )
 
         for paged_result in paged_result_iter:
-            for row in paged_result:
-                yield row
+            yield from paged_result
 
-
-    @abc.abstractmethod
+    
     def get_pages(self,
         *,
+        params: Optional[dict] = None,  # Optional alternative params
         page_size: int = 100,
-
-        retry_on_failure: bool = False,
-        max_retries: int = 5,
-        max_wait: int = 500,
-
+        step_change_version: bool = False,
+        change_version_step_size: int = 50000,
+        reverse_paging: bool = True,
         **kwargs
     ) -> Iterator[List[dict]]:
         """
         This method completes a series of GET requests, paginating params as necessary based on endpoint.
         Rows are returned as a generator.
 
-        :param page_size:
-        :param retry_on_failure:
-        :param max_retries:
-        :param max_wait:
-        :param kwargs:
+        :param params:
+        :param step_change_version:
+        :param change_version_step_size:
+        :param reverse_paging:
         :return:
         """
-        raise NotImplementedError
+        # Override init params if passed
+        paged_params = EdFiParams(params or self.params).copy()
+
+        ### Prepare pagination variables, depending on type of pagination being used
+        if step_change_version and reverse_paging:
+            logging.info(f"[Paged Get {self.component}] Pagination Method: Change Version Stepping with Reverse-Offset Pagination")
+            paged_params.init_page_by_change_version_step(change_version_step_size)
+            total_count = self.get_total_count(params=paged_params, **kwargs)
+            paged_params.init_reverse_page_by_offset(total_count, page_size)
+
+        elif step_change_version:
+            logging.info(f"[Paged Get {self.component}] Pagination Method: Change Version Stepping")
+            paged_params.init_page_by_offset(page_size)
+            paged_params.init_page_by_change_version_step(change_version_step_size)
+
+        else:
+            logging.info(f"[Paged Get {self.component}] Pagination Method: Offset Pagination")
+            paged_params.init_page_by_offset(page_size)
+
+        # Begin pagination-loop
+        while True:
+
+            ### GET from the API and yield the resulting JSON payload
+            paged_rows = self.get(params=paged_params, **kwargs)
+            logging.info(f"[Get {self.component}] Retrieved {len(paged_rows)} rows.")
+            yield paged_rows
+
+            ### Paginate, depending on the method specified in arguments
+            # Reverse offset pagination is only applicable during change-version stepping.
+            if step_change_version and reverse_paging:
+                logging.info(f"[Paged Get {self.component}] @ Reverse-paginating offset...")
+                try:
+                    paged_params.reverse_page_by_offset()
+                except StopIteration:
+                    logging.info(f"[Paged Get {self.component}] @ Reverse-paginated into negatives. Stepping change version...")
+                    try:
+                        paged_params.page_by_change_version_step()  # This raises a StopIteration if max change version is exceeded.
+                        total_count = self.get_total_count(params=paged_params, **kwargs)
+                        paged_params.init_reverse_page_by_offset(total_count, page_size)
+                    except StopIteration:
+                        logging.info(f"[Paged Get {self.component}] @ Change version exceeded max. Ending pagination.")
+                        break
+
+            else:
+                # If no rows are returned, end pagination.
+                if len(paged_rows) == 0:
+
+                    if step_change_version:
+                        try:
+                            logging.info(f"[Paged Get {self.component}] @ Stepping change version...")
+                            paged_params.page_by_change_version_step()  # This raises a StopIteration if max change version is exceeded.
+                        except StopIteration:
+                            logging.info(f"[Paged Get {self.component}] @ Change version exceeded max. Ending pagination.")
+                            break
+                    else:
+                        logging.info(f"[Paged Get {self.component}] @ Retrieved zero rows. Ending pagination.")
+                        break
+
+                # Otherwise, paginate offset.
+                else:
+                    logging.info(f"@ Paginating offset...")
+                    paged_params.page_by_offset()
 
 
-    @abc.abstractmethod
-    def total_count(self) -> int:
+    def get_total_count(self, *, params: Optional[dict] = None, **kwargs) -> int:
         """
         Ed-Fi 3 resources/descriptors can be fed an optional 'totalCount' parameter in GETs.
         This returns a 'Total-Count' in the response headers that gives the total number of rows for that resource with the specified params.
@@ -165,7 +258,20 @@ class EdFiEndpoint:
 
         :return:
         """
-        raise NotImplementedError
+        logging.info(f"[Get Total Count {self.component}] Endpoint: {self.url}")
+
+        # Override init params if passed
+        params = (params or self.params).copy()
+        params['totalCount'] = True
+        params['limit'] = 0
+
+        logging.info(f"[Get Total Count {self.component}] Parameters: {params}")
+        res = self.client.session.get_response(self.url, params, **kwargs)
+        return int(res.headers.get('Total-Count'))
+
+    def total_count(self, *args, **kwargs) -> int:
+        logging.warning("`EdFiEndpoint.total_count()` is deprecated. Use `EdFiEndpoint.get_total_count()` instead.")
+        return self.get_total_count(*args, **kwargs)
 
 
     @property
@@ -189,9 +295,12 @@ class EdFiEndpoint:
 
         :return:
         """
+        # "Resource" -> "resources"
+        swagger_type = self.component.lower() + "s"
+
         # Only GET the Swagger if not already populated in the client.
-        self.client._set_swagger(self.swagger_type)
-        swagger = self.client.swaggers[self.swagger_type]
+        self.client._set_swagger(swagger_type)
+        swagger = self.client.swaggers[swagger_type]
 
         # Populate the attributes found in the swagger.
         return {
@@ -200,392 +309,45 @@ class EdFiEndpoint:
         }
 
 
-    ### Internal GET response methods and error-handling
-    def reconnect_if_expired(func: Callable) -> Callable:
-        """
-        This decorator resets the connection with the API if expired.
-
-        :param func:
-        :return:
-        """
-        @wraps(func)
-        def wrapped(self, *args, **kwargs):
-            # Refresh token if refresh_time has passed
-            if self.client.session.refresh_time < int(time.time()):
-                self.client.verbose_log(
-                    "Session authentication is expired. Attempting reconnection..."
-                )
-                self.client.connect()
-            return func(self, *args, **kwargs)
-        return wrapped
-
-    @reconnect_if_expired
-    def _get_response(self,
-        url: str,
-        params: Optional[EdFiParams] = None
-    ) -> requests.Response:
-        """
-        Complete a GET request against an endpoint URL.
-
-        :param url:
-        :param params:
-        :return:
-        """
-        response = self.client.session.get(url, params=params)
-        self.custom_raise_for_status(response)
-        return response
-
-
-    @reconnect_if_expired
-    def _get_response_with_exponential_backoff(self,
-        url: str,
-        params: Optional[EdFiParams] = None,
-
-        *,
-        max_retries: int = 5,
-        max_wait: int = 600,
-    ) -> requests.Response:
-        """
-        Complete a GET request against an endpoint URL.
-        In the case of failure, retry with exponential backoff until max_retries or max_wait has been exceeded.
-
-        :param url:
-        :param params:
-        :param max_retries:
-        :param max_wait:
-        :return:
-        """
-        # Attempt the GET until success or `max_retries` reached.
-        for n_tries in range(max_retries):
-
-            try:
-                return self._get_response(url, params=params)
-
-            except RequestsWarning:
-                # If an API call fails, it may be due to rate-limiting.
-                # Use exponential backoff to wait, then refresh and try again.
-                time.sleep(
-                    min((2 ** n_tries) * 2, max_wait)
-                )
-                logging.warning(f"Retry number: {n_tries}")
-
-        # This block is reached only if max_retries has been reached.
-        else:
-            self.client.verbose_log(message=(
-                f"[Get with Retry Failed] Endpoint  : {url}\n"
-                f"[Get with Retry Failed] Parameters: {params}"
-            ), verbose=True)
-
-            raise RuntimeError(
-                "API GET failed: max retries exceeded for URL."
-            )
-
-
-    @staticmethod
-    def custom_raise_for_status(response):
-        """
-        Custom HTTP exception logic and logging.
-        The built-in Response.raise_for_status() fails too broadly, even in cases where a connection-reset is enough.
-
-        :param response:
-        :return:
-        """
-        if 400 <= response.status_code < 600:
-            logging.warning(
-                f"API Error: {response.status_code} {response.reason}"
-            )
-            if response.status_code == 400:
-                raise HTTPError(
-                    "400: Bad request. Check your params. Is 'limit' set too high?"
-                )
-            elif response.status_code == 401:
-                raise RequestsWarning(
-                    "401: Unauthenticated for URL. The connection may need to be reset."
-                )
-            elif response.status_code == 403:
-                # Only raise an HTTPError where the resource is impossible to access.
-                raise HTTPError(
-                    "403: Resource not authorized.",
-                    response=response
-                )
-            elif response.status_code == 404:
-                # Only raise an HTTPError where the resource is impossible to access.
-                raise HTTPError(
-                    "404: Resource not found.",
-                    response=response
-                )
-            elif response.status_code == 500:
-                raise RequestsWarning(
-                    "500: Internal server error."
-                )
-            elif response.status_code == 504:
-                raise RequestsWarning(
-                    "504: Gateway time-out for URL. The connection may need to be reset."
-                )
-            else:
-                # Otherwise, use the default error messages defined in Response.
-                response.raise_for_status()
-
-
-
-
 class EdFiResource(EdFiEndpoint):
-    """
-
-    """
-    def __init__(self,
-        client: 'EdFiClient',
-        name: str,
-
-        *,
-        namespace: str = 'ed-fi',
-        get_deletes: bool = False,
-        get_key_changes: bool = False,
-
-        params: Optional[dict] = None,
-        **kwargs
-    ):
-        super().__init__(client, name, namespace)
-        self.get_deletes: bool = get_deletes
-        self.get_key_changes: bool = get_key_changes
-        if self.get_deletes and self.get_key_changes:
-            raise ValueError("Ed-Fi Resource arguments `get_deletes` and `get_key_changes` are mutually-exclusive.")
-
-        self.url = self.build_url()
-        self.params = EdFiParams(params, **kwargs)
-
-        self.swagger_type = 'resources'
+    component: str = 'Resource'
 
 
-    def __repr__(self):
-        """
-        Resource (Deletes) (with {N} parameters) [{namespace}/{name}]
-        """
-        if self.get_deletes:
-            _extras_string = " Deletes"
-        elif self.get_key_changes:
-            _extras_string = " KeyChanges"
-        else:
-            _extras_string = ""
+class EdFiDescriptor(EdFiEndpoint):
+    component: str = 'Descriptor'
 
-        _params_string = f" with {len(self.params.keys())} parameters" if self.params else ""
-        _full_name = f"{util.snake_to_camel(self.namespace)}/{util.snake_to_camel(self.name)}"
-
-        return f"<Resource{_extras_string}{_params_string} [{_full_name}]>"
-
-
-    def build_url(self) -> str:
-        """
-        Build the name/descriptor URL to GET from the API.
-
-        :param name:
-        :param namespace:
-        :param get_deletes:
-        :return:
-        """
-        # Deletes are an optional path addition.
-        if self.get_deletes:
-            path_extra = 'deletes'
-        elif self.get_key_changes:
-            path_extra = 'keyChanges'
-        else:
-            path_extra = None
-
-        return util.url_join(
-            self.client.base_url,
-            self.client.version_url_string,
-            self.client.instance_locator,
-            self.namespace, self.name, path_extra
-        )
-
-
-    def get(self, limit: Optional[int] = None):
-        """
-        This method returns the rows from a single GET request using the exact params passed by the user.
-
-        :return:
-        """
-        self.client.verbose_log(
-            f"[Get Resource] Endpoint  : {self.url}\n"
-            f"[Get Resource] Parameters: {self.params}"
-        )
-        return super().get(limit)
-
-
-    def get_pages(self,
-        *,
-        page_size: int = 100,
-
-        retry_on_failure: bool = False,
-        max_retries: int = 5,
-        max_wait: int = 500,
-
-        step_change_version: bool = False,
-        change_version_step_size: int = 50000,
-        reverse_paging: bool = True,
-    ) -> Iterator[List[dict]]:
-        """
-        This method completes a series of GET requests, paginating params as necessary based on endpoint.
-        Rows are returned as a generator.
-
-        :param page_size:
-        :param retry_on_failure:
-        :param max_retries:
-        :param max_wait:
-        :param step_change_version:
-        :param change_version_step_size:
-        :param reverse_paging:
-        :return:
-        """
-        self.client.verbose_log(f"[Paged Get Resource] Endpoint  : {self.url}")
-
-        # Reset pagination parameters
-        paged_params = self.params.copy()
-
-        ### Prepare pagination variables, depending on type of pagination being used
-        if step_change_version and reverse_paging:
-            self.client.verbose_log(
-                f"[Paged Get Resource] Pagination Method: Change Version Stepping with Reverse-Offset Pagination"
-            )
-            paged_params.init_page_by_change_version_step(change_version_step_size)
-            total_count = self._get_total_count(paged_params)
-            paged_params.init_reverse_page_by_offset(total_count, page_size)
-
-        elif step_change_version:
-            self.client.verbose_log(
-                f"[Paged Get Resource] Pagination Method: Change Version Stepping with Offset Pagination"
-            )
-            paged_params.init_page_by_offset(page_size)
-            paged_params.init_page_by_change_version_step(change_version_step_size)
-
-        else:
-            self.client.verbose_log(
-                f"[Paged Get Resource] Pagination Method: Offset Pagination"
-            )
-            paged_params.init_page_by_offset(page_size)
-
-        # Begin pagination-loop
-        while True:
-
-            ### GET from the API and yield the resulting JSON payload
-            self.client.verbose_log(f"[Paged Get Resource] Parameters: {paged_params}")
-
-            if retry_on_failure:
-                res = self._get_response_with_exponential_backoff(
-                    self.url, params=paged_params,
-                    max_retries=max_retries, max_wait=max_wait
-                )
-            else:
-                res = self._get_response(self.url, params=paged_params)
-
-            self.client.verbose_log(f"[Paged Get Resource] Retrieved {len(res.json())} rows.")
-            yield res.json()
-
-            ### Paginate, depending on the method specified in arguments
-            # Reverse offset pagination is only applicable during change-version stepping.
-            if step_change_version and reverse_paging:
-                self.client.verbose_log("[Paged Get Resource] @ Reverse-paginating offset...")
-                try:
-                    paged_params.reverse_page_by_offset()
-                except StopIteration:
-                    self.client.verbose_log(
-                        f"[Paged Get Resource] @ Reverse-paginated into negatives. Stepping change version..."
-                    )
-                    try:
-                        paged_params.page_by_change_version_step()  # This raises a StopIteration if max change version is exceeded.
-                        total_count = self._get_total_count(paged_params)
-                        paged_params.init_reverse_page_by_offset(total_count, page_size)
-                    except StopIteration:
-                        self.client.verbose_log(
-                            f"[Paged Get Resource] @ Change version exceeded max. Ending pagination."
-                        )
-                        break
-
-            else:
-                # If no rows are returned, end pagination.
-                if len(res.json()) == 0:
-
-                    if step_change_version:
-                        try:
-                            self.client.verbose_log(f"[Paged Get Resource] @ Stepping change version...")
-                            paged_params.page_by_change_version_step()  # This raises a StopIteration if max change version is exceeded.
-                        except StopIteration:
-                            self.client.verbose_log(f"[Paged Get Resource] @ Change version exceeded max. Ending pagination.")
-                            break
-                    else:
-                        self.client.verbose_log(f"[Paged Get Resource] @ Retrieved zero rows. Ending pagination.")
-                        break
-
-                # Otherwise, paginate offset.
-                else:
-                    self.client.verbose_log(f"@ Paginating offset...")
-                    paged_params.page_by_offset()
-
-
-    def total_count(self):
-        """
-        Ed-Fi 3 resources/descriptors can be fed an optional 'totalCount' parameter in GETs.
-        This returns a 'Total-Count' in the response headers that gives the total number of rows for that resource with the specified params.
-        Non-pagination params (i.e., offset and limit) have no impact on the returned total.
-
-        :return:
-        """
-        params = self.params.copy()
-        return self._get_total_count(params)
-
-
-    def _get_total_count(self, params: EdFiParams):
-        """
-        `total_count()` is accessible by the user and during reverse offset-pagination.
-        This internal helper method prevents code needing to be defined twice.
-
-        :param params:
-        :return:
-        """
-        _params = params.copy()
-        _params['totalCount'] = True
-        _params['limit'] = 0
-
-        res = self._get_response(self.url, params=_params)
-        return int(res.headers.get('Total-Count'))
-
-
-class EdFiDescriptor(EdFiResource):
-    """
-    Ed-Fi Descriptors are used identically to Resources, but they are listed in a separate Swagger.
-
-    """
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.swagger_type = 'descriptors'
+
+        if self.get_deletes:
+            logging.warning("Descriptors do not have /deletes endpoints. Argument `get_deletes` has been ignored.")
 
 
 class EdFiComposite(EdFiEndpoint):
     """
 
     """
-    def __init__(self,
-        client: 'EdFiClient',
-        name: str,
+    component: str = 'Composite'
 
-        *,
-        namespace: str = 'ed-fi',
+    def __init__(self,
+        *args,
         composite: str = 'enrollment',
         filter_type: Optional[str] = None,
         filter_id: Optional[str] = None,
-
-        params: Optional[dict] = None,
         **kwargs
     ):
-        super().__init__(client, name, namespace)
+        # Assign composite-specific arguments that are used in `self.url`.
         self.composite: str = composite
         self.filter_type: Optional[str] = filter_type
         self.filter_id: Optional[str] = filter_id
 
-        self.url = self.build_url()
-        self.params = EdFiParams(params, **kwargs)
+        # Init after to build 'self.url' with new attributes
+        super().__init__(*args, **kwargs)
 
-        self.swagger_type = 'composites'
+        if self.get_deletes:
+            logging.warning("Composites do not have /deletes endpoints. Argument `get_deletes` has been ignored.")
+        if self.get_key_changes:
+            logging.warning("Composites do not have /keyChanges endpoints. Argument `get_key_changes` has been ignored.")
 
 
     def __repr__(self):
@@ -593,112 +355,34 @@ class EdFiComposite(EdFiEndpoint):
         Enrollment Composite                     [{namespace}/{name}]
                              with {N} parameters                      (filtered on {filter_type})
         """
-        _composite = self.composite.title()
-        _params_string = f" with {len(self.params.keys())} parameters" if self.params else ""
-        _full_name = f"{util.snake_to_camel(self.namespace)}/{util.snake_to_camel(self.name)}"
-        _filter_string = f" (filtered on {self.filter_type})" if self.filter_type else ""
+        composite = self.composite.title()
+        params_string = f" with {len(self.params.keys())} parameters" if self.params else ""
+        filter_string = f" (filtered on {self.filter_type})" if self.filter_type else ""
+        return f"<{composite} Composite{params_string} [{self.raw}]{filter_string}>"
 
-        return f"<{_composite} Composite{_params_string} [{_full_name}]{_filter_string}>"
-
-
-    def build_url(self) -> str:
+    @property
+    def url(self) -> str:
         """
         Build the composite URL to GET from the API.
 
         :return:
         """
+        base_composite_url = util.url_join(self.client.base_url, 'composites/v1', self.client.get_instance_locator())
+
         # If a filter is applied, the URL changes to match the filter type.
         if self.filter_type is None and self.filter_id is None:
-            return util.url_join(
-                self.client.base_url, 'composites/v1',
-                self.client.instance_locator,
-                self.namespace, self.composite, self.name.title()
-            )
+            return util.url_join(base_composite_url, self.namespace, self.composite, self.name.title())
 
         elif self.filter_type is not None and self.filter_id is not None:
             return util.url_join(
-                self.client.base_url, 'composites/v1',
-                self.client.instance_locator,
-                self.namespace, self.composite,
+                base_composite_url, self.namespace, self.composite,
                 self.filter_type, self.filter_id, self.name
             )
 
         else:
-            raise ValueError(
-                "`filter_type` and `filter_id` must both be specified if a filter is being applied!"
-            )
+            raise ValueError("`filter_type` and `filter_id` must both be specified if a filter is being applied!")
 
-
-    def get(self, limit: Optional[int] = None):
-        """
-        This method returns the rows from a single GET request using the exact params passed by the user.
-
-        :return:
-        """
-        self.client.verbose_log(
-            f"[Get Composite] Endpoint  : {self.url}\n"
-            f"[Get Composite] Parameters: {self.params}"
-        )
-        return super().get(limit)
-
-
-    def get_pages(self,
-        *,
-        page_size: int = 100,
-
-        retry_on_failure: bool = False,
-        max_retries: int = 5,
-        max_wait: int = 500,
-
-        **kwargs
-    ) -> Iterator[List[dict]]:
-        """
-        This method completes a series of GET requests, paginating params as necessary based on endpoint.
-        Rows are returned as a generator.
-
-        :param page_size:
-        :param retry_on_failure:
-        :param max_retries:
-        :param max_wait:
-        :return:
-        """
-        if 'step_change_version' in kwargs or 'change_version_step_size' in kwargs or 'reverse_paging' in kwargs:
-            raise KeyError(
-                "Change versions are not implemented in composites!\n"
-                "Remove `step_change_version`, `change_version_step_size`, and/or `reverse_paging` from arguments."
-            )
-
-        # Reset pagination parameters
-        paged_params = self.params.copy()
-        paged_params.init_page_by_offset(page_size)
-
-        # Begin pagination-loop
-        self.client.verbose_log(f"[Paged Get Composite] Endpoint  : {self.url}")
-
-        while True:
-            self.client.verbose_log(f"[Paged Get Composite] Parameters: {paged_params}")
-
-            if retry_on_failure:
-                res = self._get_response_with_exponential_backoff(
-                    self.url, params=paged_params,
-                    max_retries=max_retries, max_wait=max_wait
-                )
-            else:
-                res = self._get_response(self.url, params=paged_params)
-
-            # If no rows are returned, end pagination.
-            if len(res.json()) == 0:
-                self.client.verbose_log(f"[Paged Get Composite] @ Retrieved zero rows. Ending pagination.")
-                break
-
-            # Otherwise, paginate offset.
-            else:
-                self.client.verbose_log(f"[Paged Get Composite] @ Retrieved {len(res.json())} rows. Paging offset...")
-                yield res.json()
-                paged_params.page_by_offset()
-
-
-    def total_count(self):
+    def get_total_count(self, *args, **kwargs):
         """
         Ed-Fi 3 resources/descriptors can be fed an optional 'totalCount' parameter in GETs.
         This returns a 'Total-Count' in the response headers that gives the total number of rows for that resource with the specified params.
@@ -706,6 +390,43 @@ class EdFiComposite(EdFiEndpoint):
 
         :return:
         """
-        raise NotImplementedError(
-            "Total counts have not yet been implemented in Ed-Fi composites!"
-        )
+        raise NotImplementedError("Total counts have not been implemented in Ed-Fi composites!")
+
+    def get_pages(self, *, params: Optional[dict] = None, page_size: int = 100, **kwargs) -> Iterator[List[dict]]:
+        """
+        This method completes a series of GET requests, paginating params as necessary based on endpoint.
+        This is the original logic used before total-count paged-param stepping.
+        Rows are returned as a generator.
+
+        :param params:
+        :param page_size:
+        :return:
+        """
+        if kwargs.get('step_change_version'):
+            logging.warning("Change versions are not implemented in composites! Change version stepping arguments are ignored.")
+
+        logging.info(f"[Paged Get {self.component}] Endpoint: {self.url}")
+        logging.info(f"[Paged Get {self.component}] Pagination Method: Offset Pagination")
+
+        # Reset pagination parameters
+        paged_params = (params or self.params).copy()
+        paged_params.init_page_by_offset(page_size)
+
+        # Begin pagination-loop
+        while True:
+
+            ### GET from the API and yield the resulting JSON payload
+            res = self.get(params=paged_params)
+
+            # If rows have been returned, there may be more to ingest.
+            if res.json():
+                logging.info(f"[Paged Get {self.component}] Retrieved {len(res.json())} rows.")
+                yield res.json()
+
+                logging.info(f"    @ Paginating offset...")
+                paged_params.page_by_offset(page_size)
+
+            # If no rows are returned, end pagination.
+            else:
+                logging.info(f"[Paged Get {self.component}] @ Retrieved zero rows. Ending pagination.")
+                break

--- a/edfi_api_client/session.py
+++ b/edfi_api_client/session.py
@@ -1,0 +1,278 @@
+import functools
+import logging
+import time
+
+import requests
+from requests import HTTPError
+from requests.auth import HTTPBasicAuth
+from requests.exceptions import RequestsWarning
+
+from edfi_api_client import util
+
+from typing import Callable, Optional, Set, Union
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from edfi_api_client.edfi_params import EdFiParams
+
+
+class EdFiSession:
+    """
+
+    """
+    retry_status_codes: Set[int] = {401, 429, 500, 501, 503, 504}
+
+    def __init__(self,
+        oauth_url: str,
+        client_key: Optional[str],
+        client_secret: Optional[str],
+        **kwargs
+    ):
+        self.oauth_url: str = oauth_url
+        self.client_key: Optional[str] = client_key
+        self.client_secret: Optional[str] = client_secret
+
+        # Session attributes refresh on EdFiSession.connect().
+        self.session: requests.Session = None
+        self.verify_ssl: bool = None
+        self.retry_on_failure: bool = None
+        self.max_retries: int = None
+        self.max_wait: int = None
+        self.use_snapshot: bool = False
+
+        # Authentication attributes refresh on EdFiSession.connect().
+        self.authenticated_at: int = None
+        self.refresh_at: int = None
+        self.auth_headers: dict = {}
+        self.access_token: str = None
+
+    def __bool__(self) -> bool:
+        return bool(self.session)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self):
+        self.session.close()
+        self.session = None  # Force session to reset between context loops.
+
+    def connect(self, *,
+        retry_on_failure: bool = False,
+        max_retries: int = 5,
+        max_wait: int = 1200,
+        use_snapshot: bool = False,
+        verify_ssl: bool = True,
+        **kwargs
+    ) -> requests.Session:
+        """
+        Create a session with authorization headers.
+
+        :return:
+        """
+        # Overwrite session attributes.
+        self.retry_on_failure = retry_on_failure
+        self.max_retries = max_retries
+        self.max_wait = max_wait
+        self.use_snapshot = use_snapshot
+        self.verify_ssl = verify_ssl
+
+        self.session = requests.Session()
+        self.session.verify = self.verify_ssl  # Only synchronous session uses `verify` attribute.
+
+        # Update time attributes and auth headers with latest authentication information.
+        self.authenticate()
+        
+        return self
+
+
+    ### Methods to assist in authentication and retries.
+    def authenticate(self) -> dict:
+        """
+        Note: This function is identical in both synchronous and asynchronous sessions.
+        """
+        # Ensure the connection has been established before trying to refresh.
+        if not (self.client_key and self.client_secret):
+            raise requests.exceptions.ConnectionError(
+                "An established connection to the ODS is required! Provide the client_key and client_secret in EdFiClient arguments."
+            )
+        
+        # It no manual connection was made (note: async may require a different approach)
+        if not self.session:
+            self.connect()
+
+        # Only re-authenticate when necessary.
+        if self.authenticated_at:
+            if self.refresh_at < int(time.time()):
+                logging.info("Session authentication is expired. Attempting reconnection...")
+            else:
+                return self.auth_headers
+
+        # Apply snapshot header if specified.
+        self.auth_headers.update({'Use-Snapshot': str(self.use_snapshot)})
+
+        # Complete authentication.
+        auth_response = requests.post(
+            self.oauth_url,
+            auth=HTTPBasicAuth(self.client_key, self.client_secret),
+            data={'grant_type': 'client_credentials'},
+            verify=self.verify_ssl
+        )
+        auth_response.raise_for_status()
+
+        # Track when connection was established and when to refresh the access token.
+        auth_payload = auth_response.json()
+        self.authenticated_at = int(time.time())
+        self.refresh_at = int(self.authenticated_at + auth_payload.get('expires_in') - 120)
+        self.access_token = auth_payload.get('access_token')
+
+        self.auth_headers.update({
+            'Authorization': f"Bearer {self.access_token}",
+        })
+        return self.auth_headers
+
+    def _with_exponential_backoff(func: Callable):
+        """
+        Decorator to apply exponential backoff during failed requests.
+        TODO: Is this logic and status codes consistent across request types?
+        :return:
+        """
+        @functools.wraps(func)
+        def wrapped(self,
+            *args,
+            retry_on_failure: bool = False,
+            max_retries: Optional[int] = None,
+            max_wait: Optional[int] = None,
+            **kwargs
+        ):
+            """
+            Retry kwargs can be passed during Session connect or on-the-fly during requests.
+            """
+            if not (retry_on_failure or self.retry_on_failure):
+                response = func(self, *args, **kwargs)
+                self._custom_raise_for_status(response)
+                return response
+
+            # Attempt the GET until success or `max_retries` reached.
+            max_retries = max_retries or self.max_retries
+            max_wait = max_wait or self.max_wait
+
+            response = None  # Save the response between retries to raise after all retries.
+            for n_tries in range(max_retries):
+
+                try:
+                    response = func(self, *args, **kwargs)
+                    self._custom_raise_for_status(response, retry_on_failure=True)
+                    return response
+
+                except RequestsWarning as retry_warning:
+                    # If an API call fails, it may be due to rate-limiting.
+                    sleep_secs = min((2 ** n_tries) * 2, max_wait)
+                    logging.warning(f"{retry_warning} Sleeping for {sleep_secs} seconds before retry number {n_tries + 1}...")
+                    self.safe_sleep(sleep_secs)
+
+            # This block is reached only if max_retries has been reached.
+            else:
+                message = "API retry failed: max retries exceeded for URL."
+                raise HTTPError(message, response=response)
+
+        return wrapped
+
+    def safe_sleep(self, secs: int):
+        """ Sync and async methods require different approaches to sleeping. """
+        time.sleep(secs)
+
+
+    @_with_exponential_backoff
+    def get_response(self, url: str, params: Optional['EdFiParams'] = None, **kwargs) -> requests.Response:
+        """
+        Complete a GET request against an endpoint URL.
+
+        :param url:
+        :param params:
+        :return:
+        """
+        self.authenticate()  # Always try to re-authenticate
+
+        return self.session.get(url, headers=self.auth_headers, params=params)
+
+    @_with_exponential_backoff
+    def post_response(self, url: str, data: Union[str, dict], remove_snapshot_header: bool = False, **kwargs) -> requests.Response:
+        """
+        Complete a POST request against an endpoint URL.
+        Note: Responses are returned regardless of status.
+
+        :param url:
+        :param data:
+        :return:
+        """
+        self.authenticate()  # Always try to re-authenticate
+
+        post_headers = {
+            "accept": "application/json",
+            "Content-Type": "application/json",
+            **self.auth_headers
+        }
+
+        # Snapshot headers cannot be included in token_info endpoint requests.
+        if 'Use-Snapshot' in post_headers and remove_snapshot_header:
+            del post_headers['Use-Snapshot']
+
+        data = util.clean_post_row(data)
+        return self.session.post(url, headers=post_headers, data=data, **kwargs)
+
+    @_with_exponential_backoff
+    def delete_response(self, url: str, id: int, **kwargs) -> requests.Response:
+        """
+        Complete a DELETE request against an endpoint URL.
+        Note: Responses are returned regardless of status.
+
+        :param url:
+        :param id:
+        :param kwargs:
+        :return:
+        """
+        self.authenticate()  # Always try to re-authenticate
+
+        delete_url = util.url_join(url, id)
+        return self.session.delete(delete_url, headers=self.auth_headers, **kwargs)
+
+    @_with_exponential_backoff
+    def put_response(self, url: str, id: int, data: Union[str, dict], **kwargs) -> requests.Response:
+        """
+        Complete a PUT request against an endpoint URL
+        Note: Responses are returned regardless of status.
+        :param url:
+        :param id:
+        :param data:
+        """
+        self.authenticate()  # Always try to re-authenticate
+
+        put_url = util.url_join(url, id)
+        return self.session.put(put_url, headers=self.auth_headers, json=data, verify=self.verify_ssl, **kwargs)
+
+
+    ### Error response methods
+    def _custom_raise_for_status(self, response, *, retry_on_failure: bool = False):
+        """
+        Custom HTTP exception logic and logging.
+        The built-in Response.raise_for_status() fails too broadly, even in cases where a connection-reset is enough.
+
+        :param response:
+        :return:
+        """
+        error_messages = {
+            400: "400: Bad request. Check your params. Is 'limit' set too high?",
+            401: "401: Unauthenticated for URL. The connection may need to be reset.",
+            403: "403: Resource not authorized.",
+            404: "404: Resource not found.",
+            429: "429: Too many requests. The ODS is overwhelmed.",
+            500: "500: Internal server error.",
+            504: "504: Gateway time-out for URL. The connection may need to be reset.",
+        }
+
+        if 400 <= response.status_code < 600:
+            message = error_messages.get(response.status_code, response.reason)  # Default to built-in response message
+
+            if retry_on_failure and response.status_code in self.retry_status_codes:
+                raise RequestsWarning(message)  # Exponential backoff expects a RequestsWarning
+            else:
+                raise HTTPError(message, response=response)

--- a/edfi_api_client/util.py
+++ b/edfi_api_client/util.py
@@ -1,5 +1,7 @@
-import datetime
+import json
 import re
+
+from typing import Union
 
 
 def camel_to_snake(name: str) -> str:
@@ -30,3 +32,17 @@ def url_join(*args) -> str:
     return '/'.join(
         map(lambda x: str(x).rstrip('/'), filter(lambda x: x is not None, args))
     )
+
+def clean_post_row(row: Union[str, dict]) -> str:
+    """
+    Remove 'id' from a string or dictionary payload and force to a string.
+    TODO: Can this be made more efficient?
+    :return:
+    """
+    if isinstance(row, (bytes, str)):
+        row = json.loads(row)
+
+    # "Resource identifiers cannot be assigned by the client."
+    # "Value for the auto-assigned identifier property 'DescriptorId' cannot be assigned by the client"
+    row = {col: val for col, val in row.items() if not (col == 'id' or col.endswith("DescriptorId"))}
+    return json.dumps(row)


### PR DESCRIPTION
# Feature: Migrate Session from RC
<!---
Provide Title above, ensure it summarizes the work in the PR. Example PR titles templates:
* "feature/ (or build/): describe new functionality"
* "hotfix/: describe issue fix for immediate release"
* "bugfix/ (or fix/): describe issue fix, not necessary for immediate release"
* "docs/: adding or updating documentation"
-->

## Description & motivation
The [RC/0.3.0 branch](https://github.com/edanalytics/edfi_api_client/tree/rc/0.3.0) contains a number of updates to this package. Some are quality-of-life and not important to release on a strict timeline, and others are serious code refactors that add flexibility to the project as a whole.

This PR isolates one particular refactor: moving `EdFiSession` into its own class that handles all authentication and retry logic. This PR was requested by the Cloud Engineering team in preparation for a near-future update.

At a high level, this PR makes the following changes:
- Move requests session logic into its own helper class that is initialized lazily and only connects when an ODS-request is made, or when manually called to do so.
- Replace `verbose_log` print statements in favor of using the logging library.

As a side-effect of these changes, compatibility with Ed-Fi 2 has been removed in this update.

<!---
High level description your PR, and why you're making it. Is this linked to slack thread, Monday board, open
issue, a continuation to a previous PR? Link it here if relevant (use the "#" symbol for issues/PRs).
-->

## PR Merge Priority:
<!---
This checklist helps the reviewers understand the level of priority for merging this PR.
A loose description of merging priority levels is:
Low: A week or more.
Medium: Within 3 days or less.
High: As soon as possible.
-->
- [ ] Low
- [x] Medium
- [ ] High

<!---
If High Priority, explain why as a comment below.
-->

## Tests and QC done:
<!---
Describe any process that confirms that the files do what is expected, include screenshots if relevant. For example:
- Analyst replication confirmed that updates to `stg_model` new counts were correct.
- Executed a dbt project run and ensured it was successful.
-->
This has been tested interactively and by Mark in a dev process in South Carolina. One thing to still verify is that retries work identically as before on long-running GETs.
