### PR TITLE
Feature/add token options

### DIFF
--- a/edfi_api_client/session.py
+++ b/edfi_api_client/session.py
@@ -99,7 +99,9 @@ class EdFiSession:
         
         # It no manual connection was made (note: async may require a different approach)
         if not self.session:
+            # connect will call authenticate
             self.connect()
+            return self.auth_headers
 
         # Only re-authenticate when necessary.
         if self.authenticated_at:
@@ -113,14 +115,11 @@ class EdFiSession:
 
         # Defer to external token or token getter if passed
         if self.external_access_token:
-            # Only call the token getter if token has not yet been set (or has
-            # been invalidated)
-            if not self.access_token:
-                if isinstance(self.external_access_token, str):
-                    self.access_token = self.external_access_token
-                else:
-                    logging.info("Calling external token getter.")
-                    self.access_token = self.external_access_token()
+            if isinstance(self.external_access_token, str):
+                self.access_token = self.external_access_token
+            else:
+                logging.info("Calling external token getter.")
+                self.access_token = self.external_access_token()
 
         else:
             # Or, complete authentication by requesting a token.

--- a/edfi_api_client/session.py
+++ b/edfi_api_client/session.py
@@ -179,8 +179,9 @@ class EdFiSession:
                 except RequestsWarning as retry_warning:
                     # If an API call fails, it may be due to rate-limiting.
                     sleep_secs = min((2 ** n_tries) * 2, max_wait)
-                    logging.warning(f"{retry_warning} Sleeping for {sleep_secs} seconds before retry number {n_tries + 1}...")
-                    self.safe_sleep(sleep_secs)
+                    if n_tries + 1 < max_retries:
+                        logging.warning(f"{retry_warning} Sleeping for {sleep_secs} seconds before retry number {n_tries + 1}...")
+                        self.safe_sleep(sleep_secs)
 
             # This block is reached only if max_retries has been reached.
             else:

--- a/tests/test_external_tokens.py
+++ b/tests/test_external_tokens.py
@@ -1,0 +1,107 @@
+from edfi_api_client import EdFiClient
+import os
+import logging
+import pytest
+from requests import HTTPError
+
+logging.basicConfig(level=logging.DEBUG)
+
+
+def test_mutually_exclusive_authentication():
+    # not permitted to pass in client key and external token at the same time
+    with pytest.raises(ValueError):
+        bad_api = EdFiClient(
+            base_url='https://localhost/api',
+            client_key='testkey',
+            client_secret='testsecret',
+            access_token='testtoken'
+        )
+
+def test_external_token_string():
+    base_url = os.environ.get('EDFI_API_BASE_URL', 'https://localhost/api')
+    client_key = os.environ.get('EDFI_API_CLIENT_KEY', 'testkey')
+    client_secret = os.environ.get('EDFI_API_CLIENT_SECRET', 'testsecret')
+
+    # setup client that will authenticate on its own
+    parent_api = EdFiClient(
+        base_url=base_url,
+        client_key=client_key,
+        client_secret=client_secret
+    )
+
+    # make call that requires authentication (sessions are lazy)
+    parent_school_count = parent_api.resource('schools').total_count()
+    logging.info(f'Parent API yields {parent_school_count}')
+    common_token = parent_api.session.access_token
+
+    # setup client passing in the existing token
+    child_api = EdFiClient(
+        base_url=base_url,
+        access_token=common_token
+    )
+    
+    # make same call requiring authentication
+    child_school_count = child_api.resource('schools').total_count()
+    logging.info(f'Child API yields {child_school_count}')
+    
+    assert child_school_count == parent_school_count
+
+
+def test_external_token_getter():
+    base_url = os.environ.get('EDFI_API_BASE_URL', 'https://localhost/api')
+    client_key = os.environ.get('EDFI_API_CLIENT_KEY', 'testkey')
+    client_secret = os.environ.get('EDFI_API_CLIENT_SECRET', 'testsecret')
+
+    # setup client that will authenticate on its own
+    parent_api = EdFiClient(
+        base_url=base_url,
+        client_key=client_key,
+        client_secret=client_secret
+    )
+
+    # make call that requires authentication (sessions are lazy)
+    parent_school_count = parent_api.resource('schools').total_count()
+    logging.info(f'Parent API yields {parent_school_count}')
+    common_token = parent_api.session.access_token
+
+    # setup client passing in the existing token (as a getter)
+    child_api = EdFiClient(
+        base_url=base_url,
+        access_token=lambda: common_token
+    )
+    
+    # make same call requiring authentication
+    child_school_count = child_api.resource('schools').total_count()
+    logging.info(f'Child API yields {child_school_count}')
+    
+    assert child_school_count == parent_school_count
+
+
+def test_token_getter_called_on_retry():
+    '''Important if we want paged requests to be able to fetch a new token 
+    from the external token getter in the middle'''
+
+    base_url = os.environ.get('EDFI_API_BASE_URL', 'https://localhost/api')
+    
+    # pass in a bad token that will result in 401 errors
+    counter = 0
+    def token_getter():
+        nonlocal counter 
+        counter += 1
+        logging.info(f'Token getter called {counter} times')
+        return 'badtoken'
+
+    api = EdFiClient(
+        base_url=base_url,
+        access_token=token_getter
+    )
+
+    try:
+        # call that requires authentication
+        api.resource('schools').get_total_count(max_retries=2, retry_on_failure=True, max_wait=2)
+    except HTTPError:
+        # max_retries actually means max total tries; 1 try and 1 retry
+        assert counter == 2
+        
+
+        


### PR DESCRIPTION
## Description
Adds the option to pass in an existing OAuth access token when instantiating clients, either as a string or as a callable (which will be called repeatedly, on every call to `EdFiSession.authenticate`). With new default limits for how many active tokens may exist at any time, this allows for easier sharing of tokens between processes. 


## Breaking changes:
- Should be none to existing instantiations of EdFiClient; new `access_token` is a named argument so existing calls using client key/secret as positional arguments should be unaffected.

## Changes to existing files:
- `edfi_client.py`: Add `access_token` named argument to init; checks that only one of `client_secret` or `access_token` are provided.
- `session.py`: 
    - Save `access_token`, if passed, into the `external_access_token` instance variable on EdFiSession instantiation
    - In `EdFiSession.authenticate`, add a fork for getting external tokens instead of fetching one 
    - Return early out of EdFiSession.authenticate if EdFiSession.connect is called (which will call EdFiSession.authenticate anyway)
    - Skip the last sleep in `EdFiSession._with_exponential_backoff` if it's the last rety

## New files created:
- `tests/test_external_tokens.py`: Basic pytest tests for new functionality
